### PR TITLE
Compilation error on turbo jpeg

### DIFF
--- a/src/ofxMultiKinectV2.cpp
+++ b/src/ofxMultiKinectV2.cpp
@@ -97,7 +97,7 @@ void ofxMultiKinectV2::threadedFunction()
             ofBuffer tmp;
             tmp.set(&jpegBack.front(), jpegBack.size());
 #ifdef USE_OFX_TURBO_JPEG
-            turbo.load(tmp, colorPixBack);
+            turbo.load(tmp/*, colorPixBack*/);
 #else
             ofLoadImage(colorPixBack, tmp);
 #endif

--- a/src/ofxMultiKinectV2.h
+++ b/src/ofxMultiKinectV2.h
@@ -7,7 +7,7 @@
 #pragma once
 #include "ofMain.h"
 
-#define USE_OFX_TURBO_JPEG
+//#define USE_OFX_TURBO_JPEG
 
 #ifdef USE_OFX_TURBO_JPEG
 #include "ofxTurboJpeg.h"

--- a/src/ofxMultiKinectV2.h
+++ b/src/ofxMultiKinectV2.h
@@ -7,7 +7,7 @@
 #pragma once
 #include "ofMain.h"
 
-//#define USE_OFX_TURBO_JPEG
+#define USE_OFX_TURBO_JPEG
 
 #ifdef USE_OFX_TURBO_JPEG
 #include "ofxTurboJpeg.h"


### PR DESCRIPTION
Hello there !

OfxMultikinect is broken with the actual version of ofxturbojpeg (at the time of saying). I have a compilation error saying that "turbo.load" accepts only one parameter and not two.

This get fixed by simply doing the change in the pull request.

Best
